### PR TITLE
Containerize app and set up GitHub action for Docker image publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,34 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Stage 1: Build the application
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+# Stage 2: Serve the application
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY --from=builder /app ./
+
+EXPOSE 3000
+
+CMD ["npm", "run", "preview"]


### PR DESCRIPTION
Containerize the Nuxt app into a Docker image and set up a GitHub action to publish the image to ghcr.io on new commits, supporting both ARM and AMD architectures.

* **Dockerfile**
  - Create a multi-stage Dockerfile to build and serve the Nuxt app.
  - Use the `node:18-alpine` image for both build and serve stages.
  - Install dependencies, build the app, and serve it using `npm run preview`.

* **GitHub Actions Workflow**
  - Add `.github/workflows/docker-publish.yml` to automate Docker image publishing.
  - Trigger the workflow on push events to the main branch.
  - Set up QEMU and Docker Buildx for multi-architecture builds.
  - Log in to GitHub Container Registry using GitHub secrets.
  - Build and push Docker images for ARM and AMD architectures to ghcr.io.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ChandlerHardy/my-nuxt-app/pull/4?shareId=d72667aa-e86f-4774-8aba-fb929334fa10).